### PR TITLE
Check result hashes only on the files required for submission

### DIFF
--- a/compliance/check.py
+++ b/compliance/check.py
@@ -380,31 +380,11 @@ def results_check(
     results.pop("power/server.json")
     RESULT_PATHS.remove("power/server.json")
 
-    def is_same_file(path: str, ref: str) -> bool:
-        return os.path.basename(path) == os.path.basename(ref)
-
-    def find_file(path: str, pool: List[str]) -> int:
-        candidates = []
-        for i, ref_path in enumerate(pool):
-            if is_same_file(path, ref_path):
-                candidates.append((i, ref_path))
-        if len(candidates) == 1:
-            return candidates[0][0]
-        elif len(candidates) > 1:
-            for i, candidate in candidates:
-                for mode in [RANGING_MODE, TESTING_MODE]:
-                    if mode in path and mode in candidate:
-                        return i
-        return -1
-
     def remove_optional_path(res: Dict[str, str]) -> None:
         keys = list(res.keys())
         for path in keys:
-            path_idx = find_file(path, RESULT_PATHS)
-            if path_idx == -1:
-                del res[path]
-            elif path != RESULT_PATHS[path_idx]:
-                res[RESULT_PATHS[path_idx]] = res[path]
+            # Ignore all the optional files.
+            if path not in RESULT_PATHS:
                 del res[path]
 
     # We only check the hashes of the files required for submission.

--- a/compliance/check.py
+++ b/compliance/check.py
@@ -44,35 +44,22 @@ SUPPORTED_MODEL = {
     77: "YokogawaWT330E",
 }
 
-RESULT_PATHS_C = [
-    "power/client.log",
-    "ranging/mlperf_log_detail.txt",
-    "ranging/mlperf_log_summary.txt",
-    "run_1/mlperf_log_detail.txt",
-    "run_1/mlperf_log_summary.txt",
-]
+RANGING_MODE = "ranging"
+TESTING_MODE = "run_1"
 
-OPTIONAL_RESULT_PATHS_C = [
-    "ranging/mlperf_log_accuracy.json",
-    "ranging/mlperf_log_trace.json",
-    "run_1/mlperf_log_accuracy.json",
-    "run_1/mlperf_log_trace.json",
-]
-
-RESULT_PATHS_S = [
+RESULT_PATHS = [
     "power/client.json",
     "power/client.log",
     "power/ptd_logs.txt",
-    "ranging/spl.txt",
+    "power/server.json",
     "power/server.log",
-    "run_1/spl.txt",
+    os.path.join(RANGING_MODE, "mlperf_log_detail.txt"),
+    os.path.join(RANGING_MODE, "mlperf_log_summary.txt"),
+    os.path.join(RANGING_MODE, "spl.txt"),
+    os.path.join(TESTING_MODE, "mlperf_log_detail.txt"),
+    os.path.join(TESTING_MODE, "mlperf_log_summary.txt"),
+    os.path.join(TESTING_MODE, "spl.txt"),
 ]
-
-RESULT_PATHS = RESULT_PATHS_C + RESULT_PATHS_S
-
-RANGING_MODE = "ranging"
-TESTING_NODE = "testing"
-
 
 COMMON_ERROR = "Can't evaluate uncertainty of this sample!"
 COMMON_WARNING = "Uncertainty unknown for the last measurement sample!"
@@ -264,7 +251,7 @@ def phases_check(
             ), f"The time difference for {i + 1} phase of {mode} mode is equal or more than 200ms."
 
     comapre_time(phases_ranging_c, phases_ranging_s, RANGING_MODE)
-    comapre_time(phases_testing_c, phases_testing_s, TESTING_NODE)
+    comapre_time(phases_testing_c, phases_testing_s, TESTING_MODE)
 
     def compare_duration(range_duration: float, test_duration: float) -> None:
         duration_diff = abs(range_duration - test_duration) / max(
@@ -382,21 +369,50 @@ def results_check(
        Check that results from client.json and server.json have no extra and absent files.
        Compare that results files from client.json and server.json have the same checksum.
     """
+    # Hashes of the files in results directory
     results = dict(source_hashes.hash_dir(result_path))
+    # Hashes recorded in server.json
     results_s = server_sd.json_object["results"]
+    # Hashes recorded in client.json
     results_c = client_sd.json_object["results"]
 
     # TODO: server.json checksum
     results.pop("power/server.json")
+    RESULT_PATHS.remove("power/server.json")
+
+    def is_same_file(path: str, ref: str) -> bool:
+        return os.path.basename(path) == os.path.basename(ref)
+
+    def find_file(path: str, pool: List[str]) -> int:
+        candidates = []
+        for i, ref_path in enumerate(pool):
+            if is_same_file(path, ref_path):
+                candidates.append((i, ref_path))
+        if len(candidates) == 1:
+            return candidates[0][0]
+        elif len(candidates) > 1:
+            for i, candidate in candidates:
+                for mode in [RANGING_MODE, TESTING_MODE]:
+                    if mode in path and mode in candidate:
+                        return i
+        return -1
 
     def remove_optional_path(res: Dict[str, str]) -> None:
-        for path in OPTIONAL_RESULT_PATHS_C:
-            res.pop(path, "empty")
+        keys = list(res.keys())
+        for path in keys:
+            path_idx = find_file(path, RESULT_PATHS)
+            if path_idx == -1:
+                del res[path]
+            elif path != RESULT_PATHS[path_idx]:
+                res[RESULT_PATHS[path_idx]] = res[path]
+                del res[path]
 
+    # We only check the hashes of the files required for submission.
     remove_optional_path(results_s)
     remove_optional_path(results_c)
     remove_optional_path(results)
 
+    # Make sure the hashes match between server.json and client.json
     compare_dicts_values(
         results_s,
         results_c,
@@ -405,33 +421,30 @@ def results_check(
     compare_dicts_values(
         results_c,
         results_s,
-        f"{server_sd.path} and {client_sd.path} results checksum comparison",
+        f"{client_sd.path} and {server_sd.path} results checksum comparison",
     )
 
+    # Check if the hashes of the files in results directory match the ones recorded in server.json/client.json.
     result_c_s = {**results_c, **results_s}
 
     compare_dicts(
         result_c_s,
         results,
-        f"{server_sd.path} 'results' checksum values and calculated {result_path} content checksum comparison:\n",
+        f"{server_sd.path} + {client_sd.path} results checksum values and calculated {result_path} content checksum comparison:\n",
     )
 
+    # Check if all the required files are present
     def result_files_compare(
         res: Dict[str, str], ref_res: List[str], path: str
     ) -> None:
-        extra_files = set(res.keys()) - set(ref_res)
-        assert (
-            len(extra_files) == 0
-        ), f"There are extra files {', '.join(extra_files)!r} in the results of {path}"
-
+        # If a file is required (in ref_res) but is not present in results directory (res),
+        # then the submission is invalid.
         absent_files = set(ref_res) - set(res.keys())
         assert (
             len(absent_files) == 0
         ), f"There are absent files {', '.join(absent_files)!r} in the results of {path}"
 
-    result_files_compare(result_c_s, RESULT_PATHS, server_sd.path)
-    result_files_compare(results_c, RESULT_PATHS_C, client_sd.path)
-
+    result_files_compare(results, RESULT_PATHS, result_path)
 
 def check_ptd_logs(server_sd: SessionDescriptor, path: str) -> None:
     """Check if ptd message starts with 'WARNING' or 'ERROR' in ptd logs.

--- a/compliance/check.py
+++ b/compliance/check.py
@@ -424,6 +424,7 @@ def results_check(
             len(absent_files) == 0
         ), f"There are absent files {', '.join(absent_files)!r} in the results of {path}"
 
+    result_files_compare(result_c_s, RESULT_PATHS, f"{server_sd.path} + {client_sd.path}")
     result_files_compare(results, RESULT_PATHS, result_path)
 
 def check_ptd_logs(server_sd: SessionDescriptor, path: str) -> None:


### PR DESCRIPTION
- Remove checking on non-required files.
- Remove errors when extra files are present.
- Make the checks more robust to directory structure changes.

