### PR TITLE
fix error usb

### DIFF
--- a/compliance/check.py
+++ b/compliance/check.py
@@ -65,6 +65,7 @@ RESULT_PATHS = [
 COMMON_ERROR_RANGING = ["Can't evaluate uncertainty of this sample!"]
 COMMON_ERROR_TESTING = ["USB."]
 
+
 def _normalize(path: str) -> str:
     allparts: List[str] = []
     while 1:
@@ -525,7 +526,11 @@ def check_ptd_logs(
                 assert (
                     start_ranging_time < log_time < stop_ranging_time
                 ), f"{line.strip()!r} in ptd_log.txt"
-                if not problem_line.group(0).strip().startswith(COMMON_ERROR_RANGING[0]):
+                if (
+                    not problem_line.group(0)
+                    .strip()
+                    .startswith(COMMON_ERROR_RANGING[0])
+                ):
                     raise CheckerWarning(
                         f"{line.strip()!r} in ptd_log.txt during ranging stage. Treated as WARNING"
                     )

--- a/compliance/check.py
+++ b/compliance/check.py
@@ -62,7 +62,8 @@ RESULT_PATHS = [
     TESTING_MODE + "/spl.txt",
 ]
 
-COMMON_ERROR = ["Can't evaluate uncertainty of this sample!","USB."]
+COMMON_ERROR_RANGING = ["Can't evaluate uncertainty of this sample!"]
+COMMON_ERROR_TESTING = ["USB."]
 
 def _normalize(path: str) -> str:
     allparts: List[str] = []
@@ -517,14 +518,14 @@ def check_ptd_logs(
             if start_ranging_time is None or stop_ranging_time is None:
                 assert False, "Can not find ranging time in ptd_logs.txt."
             if error:
-                if problem_line.group(0).strip() == COMMON_ERROR[1]:
+                if problem_line.group(0).strip() == COMMON_ERROR_TESTING[0]:
                     raise CheckerWarning(
                         f"{line.strip()!r} in ptd_log.txt during ranging stage. Treated as WARNING"
                     )
                 assert (
                     start_ranging_time < log_time < stop_ranging_time
                 ), f"{line.strip()!r} in ptd_log.txt"
-                if not problem_line.group(0).strip().startswith(COMMON_ERROR[0]):
+                if not problem_line.group(0).strip().startswith(COMMON_ERROR_RANGING[0]):
                     raise CheckerWarning(
                         f"{line.strip()!r} in ptd_log.txt during ranging stage. Treated as WARNING"
                     )

--- a/compliance/check.py
+++ b/compliance/check.py
@@ -62,8 +62,7 @@ RESULT_PATHS = [
     TESTING_MODE + "/spl.txt",
 ]
 
-COMMON_ERROR = "Can't evaluate uncertainty of this sample!"
-
+COMMON_ERROR = ["Can't evaluate uncertainty of this sample!","USB."]
 
 def _normalize(path: str) -> str:
     allparts: List[str] = []
@@ -518,10 +517,14 @@ def check_ptd_logs(
             if start_ranging_time is None or stop_ranging_time is None:
                 assert False, "Can not find ranging time in ptd_logs.txt."
             if error:
+                if problem_line.group(0).strip() == COMMON_ERROR[1]:
+                    raise CheckerWarning(
+                        f"{line.strip()!r} in ptd_log.txt during ranging stage. Treated as WARNING"
+                    )
                 assert (
                     start_ranging_time < log_time < stop_ranging_time
                 ), f"{line.strip()!r} in ptd_log.txt"
-                if not problem_line.group(0).strip().startswith(COMMON_ERROR):
+                if not problem_line.group(0).strip().startswith(COMMON_ERROR[0]):
                     raise CheckerWarning(
                         f"{line.strip()!r} in ptd_log.txt during ranging stage. Treated as WARNING"
                     )

--- a/compliance/check.py
+++ b/compliance/check.py
@@ -520,7 +520,7 @@ def check_ptd_logs(
             if error:
                 if problem_line.group(0).strip() == COMMON_ERROR_TESTING[0]:
                     raise CheckerWarning(
-                        f"{line.strip()!r} in ptd_log.txt during ranging stage. Treated as WARNING"
+                        f"{line.strip()!r} in ptd_log.txt during testing stage but it is accepted. Treated as WARNING"
                     )
                 assert (
                     start_ranging_time < log_time < stop_ranging_time


### PR DESCRIPTION
Fixes error usb as seen here:  https://github.com/mlcommons/power-dev/issues/250#issuecomment-889973175

```
(mlperf) rakshith@mlperf-inference-rakshith-x86_64:/work/build/power-dev$ python compliance/check.py /work/results/R750xa_A100-PCIE-80GBx4_TRT/resnet50/Server/performance
[ ] Check client sources checksum
        {'__init__.py': 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'client.py': '33ca4f26368777ac06e01f9567b714a4b8063886', 'lib/__init__.py': 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'lib/client.py': '4c2b78fb4849a7e5b584ef792d82aaed20b17f57', 'lib/common.py': '624d0c0acc7c39aaff3674f0b99d6a09da53d1dc', 'lib/external/__init__.py': 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'lib/external/ntplib.py': '4da8f970656505a40483206ef2b5d3dd5e81711d', 'lib/server.py': '326f7489b6e80111c0be437e0cd266499b26fa6e', 'lib/source_hashes.py': '60a2e02193209e8d392803326208d5466342da18', 'lib/summary.py': 'aa92f0a3f975eecd44d3c0cd0236342ccc9f941d', 'lib/time_sync.py': '3210db56eb0ff0df57bf4293dc4d4b03fffd46f1', 'server.py': 'c3f90f2f7eeb4db30727556d0c815ebc89b3d28b', 'tests/unit/__init__.py': 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'tests/unit/test_server.py': '99ae15aef722f2000ee6ed1ae1523637bf1ae42b', 'tests/unit/test_source_hashes.py': '00468a2907583c593e6574a1f6b404e4651c221a'} do not exist in 'sources_checksums.json'

[x] Check server sources checksum
[x] Check PTD commands and replies
[x] Check UUID
[x] Check session name
[x] Check time difference
[x] Check client server messages
[x] Check results checksum
[x] Check errors and warnings from PTD logs
        '07-28-2021 15:18:10.465: ERROR: USB.' in ptd_log.txt during ranging stage. Treated as WARNING

[x] Check PTD configuration
[x] Check debug is disabled on server-side

ERROR: Not all checks passed. Warnings encountered, check for audit!
```


FYI: @nvpohanh @psyhtest @s-idgunji 