### PR TITLE
Add option for auto/max ranging

### DIFF
--- a/compliance/sources_checksums.json
+++ b/compliance/sources_checksums.json
@@ -49,5 +49,22 @@
         "tests/unit/test_server.py": "99ae15aef722f2000ee6ed1ae1523637bf1ae42b",
         "tests/unit/test_source_hashes.py": "00468a2907583c593e6574a1f6b404e4651c221a",
         "tests/unit/__init__.py": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+    },
+    {
+        "server.py": "c3f90f2f7eeb4db30727556d0c815ebc89b3d28b",
+        "client.py": "33ca4f26368777ac06e01f9567b714a4b8063886",
+        "__init__.py": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "tests/unit/test_source_hashes.py": "00468a2907583c593e6574a1f6b404e4651c221a",
+        "tests/unit/__init__.py": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "tests/unit/test_server.py": "99ae15aef722f2000ee6ed1ae1523637bf1ae42b",
+        "lib/source_hashes.py": "60a2e02193209e8d392803326208d5466342da18",
+        "lib/server.py": "cda0cdfaee9bfa1249c64a7dd4f89b7bf1b279f0",
+        "lib/client.py": "4c2b78fb4849a7e5b584ef792d82aaed20b17f57",
+        "lib/__init__.py": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "lib/summary.py": "aa92f0a3f975eecd44d3c0cd0236342ccc9f941d",
+        "lib/time_sync.py": "3210db56eb0ff0df57bf4293dc4d4b03fffd46f1",
+        "lib/common.py": "624d0c0acc7c39aaff3674f0b99d6a09da53d1dc",
+        "lib/external/ntplib.py": "4da8f970656505a40483206ef2b5d3dd5e81711d",
+        "lib/external/__init__.py": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
     }
 ]

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -63,6 +63,17 @@ MULTICHANNEL_DEVICES = [48, 59, 61, 77]
 # https://github.com/mlcommons/power-dev/issues/220#issue-835336923
 DEVICE_TYPE_WT500 = 48
 
+MAX_RANGE_FOR_DEVICE = {
+    8: 20,  # WT210
+    49: 20,  # WT310
+    52: 20,  # WT330
+    77: 20,  # WT330_multichannel
+    35: 40,  # WT500
+    48: 40,  # WT500_multichannel
+    47: 50,  # WT1800
+    66: 30,  # WT5000
+}
+
 
 class MeasurementEndedTooFastError(Exception):
     pass
@@ -268,6 +279,7 @@ class ServerConfig:
             parse=get_host_port_from_listen_string,
             fallback=f"0.0.0.0 {common.DEFAULT_PORT}",
         )
+        self.ranging_mode = get("server", "rangingMode", fallback="AUTO")
 
         self.ptd_channel: Optional[List[int]] = get(
             "ptd", "channel", parse=parse_channel, fallback=None
@@ -770,7 +782,21 @@ class Session:
             self._server._summary.phase("ranging", 0)
             self._ptd.start()
             self._ptd.cmd("SR,V,Auto")
-            self._ptd.cmd("SR,A,Auto")
+            if self._server._config.ranging_mode == "AUTO":
+                self._ptd.cmd("SR,A,Auto")
+            elif self._server._config.ranging_mode == "MAX":
+                ptd_device_type = self._server._config.ptd_device_type
+                if ptd_device_type in MAX_RANGE_FOR_DEVICE:
+                    self._ptd.cmd(f"SR,A,{MAX_RANGE_FOR_DEVICE[ptd_device_type]}")
+                else:
+                    logging.warning(
+                        f"Unknown max range type for device {ptd_device_type}, using AUTO"
+                    )
+                    self._ptd.cmd("SR,A,Auto")
+            else:
+                logging.warning("Unknown range mode, using AUTO")
+                self._ptd.cmd("SR,A,Auto")
+
             with common.sig:
                 time.sleep(ANALYZER_SLEEP_SECONDS)
             logging.info("Starting ranging mode")

--- a/ptd_client_server/server.template.conf
+++ b/ptd_client_server/server.template.conf
@@ -4,7 +4,7 @@
 [server]
 # NTP server to sync with before each measurement.
 # See "NTP" section in the README.md.
-#ntpServer: ntp.example.com
+# ntpServer: ntp.example.com
 
 # A directory to store output data. A relative or absolute path could be used.
 # A new subdirectory will be created per each run.
@@ -16,8 +16,10 @@ outDir: D:\ptd-logs\
 
 # (Optional) IP address and port that server listen on
 # Defaults to "0.0.0.0 4950" if not set
-#listen: 192.168.1.2 4950
+# listen: 192.168.1.2 4950
 
+# (Optional) Range settings to set the mode for the ranging run. AUTO or MAX
+# rangingMode: AUTO
 
 # PTDaemon configuration.
 # The following options are mapped to PTDaemon command line arguments.


### PR DESCRIPTION
Fix #260 
- Add option into server configuration to choose between AUTO or MAX ranging run. (Not 100% sure if this is the correct place to put it, any thoughts?)
- Run auto or max ranging according to this parameter
- Reintroduce the changes removed in this [PR](https://github.com/mlcommons/power-dev/pull/257/files)