### PR TITLE
Add Yokogawa WT330 as supported meter

### DIFF
--- a/compliance/check.py
+++ b/compliance/check.py
@@ -41,6 +41,7 @@ SUPPORTED_MODEL = {
     "YokogawaWT500_multichannel": 48,
     "YokogawaWT310": 49,
     "YokogawaWT310E": 49,
+    "YokogawaWT330": 52,
     "YokogawaWT330E": 52,
     "YokogawaWT330_multichannel": 77,
 }


### PR DESCRIPTION
[Previously](https://github.com/mlcommons/power-dev/issues/238), we recognized WT310 and WT310E as one device for all intents and purposes of MLPerf Power. This change similarly recognizes WT330 and WT330E as one.

Fixes https://github.com/mlcommons/power-dev/issues/266