### PR TITLE
Add Yokogawa WT330 as supported meter. Fixes #266

### DIFF
--- a/compliance/check.py
+++ b/compliance/check.py
@@ -41,6 +41,7 @@ SUPPORTED_MODEL = {
     "YokogawaWT500_multichannel": 48,
     "YokogawaWT310": 49,
     "YokogawaWT310E": 49,
+    "YokogawaWT330": 52,
     "YokogawaWT330E": 52,
     "YokogawaWT330_multichannel": 77,
 }


### PR DESCRIPTION
This change is taken from the r2.1 branch and is the only change from r2.1 branch missing in the master.