### PR TITLE
updating per SPEC guide

### DIFF
--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -452,11 +452,13 @@ class Ptd:
         self._get_initial_range()
 
     def grab_power_data(self) -> List[str]:
-        #(DM) Created method that will utilize SPEC's (only) preferred way of PTD usage and data gathering
+        # (DM) Created method that will utilize SPEC's (only) preferred way of PTD usage and data gathering
         power_data_header = self.cmd("RL")  # RL - command to show unread samples
-        number_of_samples = power_data_header.split(' ')[1] # first line of response will have message: "Last XYZ samples"
+        number_of_samples = power_data_header.split(" ")[
+            1
+        ]  # first line of response will have message: "Last XYZ samples"
         try:
-            number_of_samples = int(power_data_header.split(' ')[1])
+            number_of_samples = int(power_data_header.split(" ")[1])
         except:
             number_of_samples = 0
         grabbed_power_data = self.read(number_of_samples)
@@ -466,7 +468,7 @@ class Ptd:
             number_of_samples,
             grabbed_power_data,
             grabbed_uncertainty_data,
-            grabbed_sanity_chk_data
+            grabbed_sanity_chk_data,
         )
 
     def stop(self) -> None:
@@ -526,7 +528,7 @@ class Ptd:
         return reply
 
     def read(self, number: int) -> List[str]:
-        #(DM) had to add method that will unprovokedly read "number" of lines, so we can get all power data
+        # (DM) had to add method that will unprovokedly read "number" of lines, so we can get all power data
         reply = ""
         if self._proto is None:
             return None
@@ -882,10 +884,10 @@ class Session:
         if mode == Mode.RANGING and self._state == SessionState.RANGING:
             self._state = SessionState.RANGING_DONE
             self._ptd.stop()
-            samples, log_data, uncertainty_data, sanity = self._ptd.grab_power_data() 
+            samples, log_data, uncertainty_data, sanity = self._ptd.grab_power_data()
             # (DM) TODO: figure out how to flag/report number of unvertain samples and how to disqualify bad run(s)
             formatted_log_data = log_data.replace(
-                "\n", str(",Mark," + self._id+"_ranging\n")
+                "\n", str(",Mark," + self._id + "_ranging\n")
             )  # honoring format of legacy spl.txt
             assert self._go_command_time is not None
             test_duration = time.monotonic() - self._go_command_time
@@ -929,7 +931,7 @@ class Session:
             self._ptd.stop()
             dirname = os.path.join(self.log_dir_path, "run_1")
             os.mkdir(dirname)
-            samples, log_data, uncertainty_data, sanity = self._ptd.grab_power_data() 
+            samples, log_data, uncertainty_data, sanity = self._ptd.grab_power_data()
             # (DM) TODO: figure out how to flag/report number of unvertain samples and how to disqualify bad run(s)
             formatted_log_data = log_data.replace(
                 "\n", str(",Mark," + self._id + "_testing\n")

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -455,9 +455,9 @@ class Ptd:
         # (DM) Created method that will utilize SPEC's (only) preferred way of PTD usage and data gathering
         power_data_header = self.cmd("RL")  # RL - command to show unread samples
         if power_data_header is not None:
-            number_of_samples = int(power_data_header.split(" ")[
-                1
-            ])  # first line of response will have message: "Last XYZ samples"
+            number_of_samples = int(
+                power_data_header.split(" ")[1]
+            )  # first line of response will have message: "Last XYZ samples"
         else:
             number_of_samples = 0
         grabbed_power_data = self.read(number_of_samples)

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -451,16 +451,18 @@ class Ptd:
 
         self._get_initial_range()
 
-    def grab_power_data(self) -> Tuple[int, List[str], Optional[str], Optional[str]]:
+    def grab_power_data(self) -> Tuple[int, str, Optional[str], Optional[str]]:
         # (DM) Created method that will utilize SPEC's (only) preferred way of PTD usage and data gathering
         power_data_header = self.cmd("RL")  # RL - command to show unread samples
         if power_data_header is not None:
-            number_of_samples = power_data_header.split(" ")[
+            number_of_samples = int(power_data_header.split(" ")[
                 1
-            ]  # first line of response will have message: "Last XYZ samples"
+            ])  # first line of response will have message: "Last XYZ samples"
         else:
             number_of_samples = 0
         grabbed_power_data = self.read(number_of_samples)
+        if grabbed_power_data is None:
+            exit_with_error_msg("Failed to get power data")
         grabbed_uncertainty_data = self.cmd("Uncertainty")
         grabbed_sanity_chk_data = self.cmd("Watts")
         return (

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -462,7 +462,12 @@ class Ptd:
         grabbed_power_data = self.read(number_of_samples)
         grabbed_uncertainty_data = self.cmd("Uncertainty")
         grabbed_sanity_chk_data = self.cmd("Watts")
-        return number_of_samples, grabbed_power_data, grabbed_uncertainty_data, grabbed_sanity_chk_data
+        return (
+            number_of_samples,
+            grabbed_power_data,
+            grabbed_uncertainty_data,
+            grabbed_sanity_chk_data
+        )
 
     def stop(self) -> None:
         self.cmd("Stop")
@@ -878,8 +883,10 @@ class Session:
             self._state = SessionState.RANGING_DONE
             self._ptd.stop()
             samples, log_data, uncertainty_data, sanity = self._ptd.grab_power_data() 
-            #(DM) TODO: figure out how to flag/report number of unvertain samples and how to disqualify bad run(s)
-            formatted_log_data = log_data.replace("\n", str(",Mark,"+self._id+"_ranging\n")) # honoring format of legacy spl.txt
+            # (DM) TODO: figure out how to flag/report number of unvertain samples and how to disqualify bad run(s)
+            formatted_log_data = log_data.replace(
+                "\n", str(",Mark," + self._id+"_ranging\n")
+            )  # honoring format of legacy spl.txt
             assert self._go_command_time is not None
             test_duration = time.monotonic() - self._go_command_time
             dirname = os.path.join(self.log_dir_path, "ranging")
@@ -923,8 +930,10 @@ class Session:
             dirname = os.path.join(self.log_dir_path, "run_1")
             os.mkdir(dirname)
             samples, log_data, uncertainty_data, sanity = self._ptd.grab_power_data() 
-            #(DM) TODO: figure out how to flag/report number of unvertain samples and how to disqualify bad run(s)
-            formatted_log_data = log_data.replace("\n", str(",Mark,"+self._id+"_testing\n")) # honoring format of legacy spl.txt
+            # (DM) TODO: figure out how to flag/report number of unvertain samples and how to disqualify bad run(s)
+            formatted_log_data = log_data.replace(
+                "\n", str(",Mark," + self._id + "_testing\n")
+            )  # honoring format of legacy spl.txt
             with open(os.path.join(dirname, "spl.txt"), "w") as f:
                 f.write(formatted_log_data)
             self._server._summary.phase("testing", 3)

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -452,17 +452,24 @@ class Ptd:
         self._get_initial_range()
 
     def grab_power_data(self) -> List[str]:
-        #(DM) Created method that will utilize SPEC's (only) preferred way of PTD usage and data gathering
+        # (DM) Created method that will utilize SPEC's (only) preferred way of PTD usage and data gathering
         power_data_header = self.cmd("RL")  # RL - command to show unread samples
-        number_of_samples = power_data_header.split(' ')[1] # first line of response will have message: "Last XYZ samples"
+        number_of_samples = power_data_header.split(" ")[
+            1
+        ] # first line of response will have message: "Last XYZ samples"
         try:
-            number_of_samples = int(power_data_header.split(' ')[1])
+            number_of_samples = int(power_data_header.split(" ")[1])
         except:
             number_of_samples = 0
         grabbed_power_data = self.read(number_of_samples)
         grabbed_uncertainty_data = self.cmd("Uncertainty")
         grabbed_sanity_chk_data = self.cmd("Watts")
-        return number_of_samples, grabbed_power_data, grabbed_uncertainty_data, grabbed_sanity_chk_data
+        return (
+            number_of_samples, 
+            grabbed_power_data, 
+            grabbed_uncertainty_data, 
+            grabbed_sanity_chk_data
+        )
 
     def stop(self) -> None:
         self.cmd("Stop")
@@ -521,7 +528,7 @@ class Ptd:
         return reply
 
     def read(self, number: int) -> List[str]:
-        #(DM) had to add method that will unprovokedly read "number" of lines, so we can get all power data
+        # (DM) had to add method that will unprovokedly read "number" of lines, so we can get all power data
         reply = ""
         if self._proto is None:
             return None
@@ -880,8 +887,10 @@ class Session:
             self._state = SessionState.RANGING_DONE
             self._ptd.stop()
             samples, log_data, uncertainty_data, sanity = self._ptd.grab_power_data() 
-            #(DM) TODO: figure out how to flag/report number of unvertain samples and how to disqualify bad run(s)
-            formatted_log_data = log_data.replace("\n", str(",Mark,"+self._id+"_ranging\n")) # honoring format of legacy spl.txt
+            # (DM) TODO: figure out how to flag/report number of unvertain samples and how to disqualify bad run(s)
+            formatted_log_data = log_data.replace(
+                "\n", str(",Mark,"+self._id+"_ranging\n")
+            )  # honoring format of legacy spl.txt
             assert self._go_command_time is not None
             test_duration = time.monotonic() - self._go_command_time
             dirname = os.path.join(self.log_dir_path, "ranging")
@@ -908,11 +917,11 @@ class Session:
                     channels_amount,
                 )
                 # we will generate crude max power approximation
-                self._maxWatts = float(float(self._maxAmps)*float(self._maxVolts))
+                self._maxWatts = float(float(self._maxAmps) * float(self._maxVolts))
                 if self._maxWatts > 75:
-                    self._desirableCurrentRange = str(float(self._maxAmps)*1.1)
+                    self._desirableCurrentRange = str(float(self._maxAmps) * 1.1)
                 else:
-                    self._desirableCurrentRange = str(float(self._maxAmps)*1.5)
+                    self._desirableCurrentRange = str(float(self._maxAmps) * 1.5)
 
 
             except MaxVoltsAmpsNegativeValuesError as e:
@@ -932,8 +941,10 @@ class Session:
             dirname = os.path.join(self.log_dir_path, "run_1")
             os.mkdir(dirname)
             samples, log_data, uncertainty_data, sanity = self._ptd.grab_power_data() 
-            #(DM) TODO: figure out how to flag/report number of unvertain samples and how to disqualify bad run(s)
-            formatted_log_data = log_data.replace("\n", str(",Mark,"+self._id+"_testing\n")) # honoring format of legacy spl.txt
+            # (DM) TODO: figure out how to flag/report number of unvertain samples and how to disqualify bad run(s)
+            formatted_log_data = log_data.replace(
+                "\n", str(",Mark,"+self._id+"_testing\n")
+            )  # honoring format of legacy spl.txt
             with open(os.path.join(dirname, "spl.txt"), "w") as f:
                 f.write(formatted_log_data)
             self._server._summary.phase("testing", 3)


### PR DESCRIPTION
SPEC guide for PTD recommends use of Telnet commands ("RL") to grab power, rather that using ptd.log.
I made changes that should make process indistinguishable from previous process (spl.tx will still be created in ranging and run_1 folders), only change is the origin of that data