### PR TITLE
Add an important note to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Power
 
+**IMPORTANT: DO NOT USE MASTER** - If you are making an MLPerf submission, DO NOT use the master branch. See the appropriate release branch. 
+
 This repo contains the development branch of MLPerf™ power measurement code. Everything is Apache 2.0 code developed by MLCommons™. Access is available to anyone.
 
 MLPerf™ is using [SPEC PTDaemon] tool for measuring power. Please see [this](https://github.com/mlcommons/power-dev/tree/master/ptd_client_server) README for more details on how to use it. 


### PR DESCRIPTION
Most MLPerf repositories use master as their source of truth. We should either migrate to that or clearly indicate not to use this branch.