### PR TITLE
Fix inference issue 1338, use time_sync to check the time difference

### DIFF
--- a/ptd_client_server/lib/client.py
+++ b/ptd_client_server/lib/client.py
@@ -270,7 +270,6 @@ def main() -> None:
         ):
             exit()
 
-
     summary.client_uuid = uuid.uuid4()
     try:
         session = command(f"new,{args.label},{summary.client_uuid}")

--- a/ptd_client_server/lib/client.py
+++ b/ptd_client_server/lib/client.py
@@ -264,6 +264,13 @@ def main() -> None:
 
     sync_check()
 
+    def sync_check_with_remote() -> None:
+        if not time_sync.sync_check_with_remote(
+            lambda: float(command("time")),
+        ):
+            exit()
+
+
     summary.client_uuid = uuid.uuid4()
     try:
         session = command(f"new,{args.label},{summary.client_uuid}")
@@ -311,14 +318,17 @@ def main() -> None:
             command(f"session,{session},start,{mode}", check=True)
 
         summary.phase(mode, 1)
+        sync_check_with_remote()
         logging.info(f"Running the workload {args.run_workload!r}")
         time_load_start = time.time()
         subprocess.run(args.run_workload, shell=True, check=True)
         time_load_end = time.time()
+        sync_check_with_remote()
         summary.phase(mode, 2)
 
         command(f"session,{session},stop,{mode}", check=True)
         summary.phase(mode, 3)
+        sync_check_with_remote()
 
         loadgen_logs = find_loadgen_logs(
             args.loadgen_logs, time_load_start, time_load_end

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -488,7 +488,6 @@ class Ptd:
 
     def terminate(self) -> None:
         if self._proto is not None:
-            self.cmd("Stop")
             self.cmd(f"SR,V,{self._init_Volts}")
             self.cmd(f"SR,A,{self._init_Amps}")
             logging.info(

--- a/ptd_client_server/lib/time_sync.py
+++ b/ptd_client_server/lib/time_sync.py
@@ -78,6 +78,18 @@ def sync(
         return False
     return True
 
+def sync_check_with_remote(
+    get_remote_time: Callable[[], float],
+) -> bool:
+    try:
+        if not validate_remote(get_remote_time):
+            logging.error("Could not synchronize with the server")
+            return False
+    except Exception:
+        logging.exception("Got an exception. Could not synchronize")
+        return False
+    return True
+
 
 def validate_remote(command: Callable[[], float]) -> bool:
     time1 = time.time()

--- a/ptd_client_server/lib/time_sync.py
+++ b/ptd_client_server/lib/time_sync.py
@@ -78,6 +78,7 @@ def sync(
         return False
     return True
 
+
 def sync_check_with_remote(
     get_remote_time: Callable[[], float],
 ) -> bool:


### PR DESCRIPTION
Instead of both server and client logging time in the log and the checker checking for their time difference, here time_sync function is used to check the time difference between client and server after each phase of the run and if the difference is > 200ms, the error gets written to the client.log file which is checked by the checker. 