### PR TITLE
Prevent sync action in forked repositories

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    if: github.repository == 'mlcommons/power-dev'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@master


### PR DESCRIPTION
Restrict the github action to mlcommons repository