### PR TITLE
Change Critical Difference to 400ms

### DIFF
--- a/ptd_client_server/lib/time_sync.py
+++ b/ptd_client_server/lib/time_sync.py
@@ -24,7 +24,7 @@ import time
 from ptd_client_server.lib.external import ntplib  # type: ignore
 
 
-CRITICAL_DIFFERENCE_TIME_MS = 200
+CRITICAL_DIFFERENCE_TIME_MS = 400
 
 
 def get_ntp_response(server: str) -> Any:


### PR DESCRIPTION
Currently at least one submitters with a lower power system is running into issues achieving a 200ms sync. 

This increases in the window to 400ms.

See discussion here:
https://groups.google.com/a/mlcommons.org/g/power/c/tes-gPJlbzk