### PR TITLE
fixing telnet not giving all the channels

### DIFF
--- a/compliance/check.py
+++ b/compliance/check.py
@@ -49,6 +49,9 @@ SUPPORTED_MODEL = {
     "YokogawaWT330": 52,
     "YokogawaWT330E": 52,
     "YokogawaWT330_multichannel": 77,
+    "YokogawaWT210_DC": 508,
+    "YokogawaWT310_DC": 549,
+    "YokogawaWT330_DC": 586,
 }
 
 RANGING_MODE = "ranging"

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -484,7 +484,9 @@ class Ptd:
                 power_data_header = self.cmd(
                     PTD_READ_ALL_COMMAND_AC
                 )  # RL - command to show unread samples in case of singlechannel AC
-            elif power_data_header is not None and re.search("Unknown command", power_data_header):
+            elif power_data_header is not None and re.search(
+                "Unknown command", power_data_header
+            ):
                 power_data_header = self.cmd(
                     PTD_READ_ALL_COMMAND_DC
                 )  # DC-RL - command to show unread samples in case of DC meter

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -965,10 +965,15 @@ class Session:
                 line_fixed = ""
                 for jj in range(len(temp)):
                     line_fixed += temp[jj]
-                    if jj > 0 and jj < len(temp) - 1:
+                    if jj > 0 and (jj < len(temp) - 1 or len(temp) == 2):
                         if jj == 1:
-                            line_fixed += "Mark," + self._id + "_ranging,"
-                        line_fixed += "Ch" + str(jj) + ","
+                            if len(temp) == 2:
+                                line_fixed += ","
+                            line_fixed += "Mark," + self._id + "_ranging"
+                            if len(temp) > 2:
+                                line_fixed += ","
+                        if len(temp) > 2:
+                            line_fixed += "Ch" + str(jj) + ","
                     if jj < len(temp) - 1:
                         line_fixed += "Watts"
                 formatted_log_data += line_fixed + "\n"
@@ -1034,10 +1039,26 @@ class Session:
             dirname = os.path.join(self.log_dir_path, "run_1")
             os.mkdir(dirname)
             samples, log_data, uncertainty_data, sanity = self._ptd.grab_power_data()
-            # (DM) TODO: figure out how to flag/report number of unvertain samples and how to disqualify bad run(s)
-            formatted_log_data = log_data.replace(
-                "\n", str(",Mark," + self._id + "_testing\n")
-            )  # honoring format of legacy spl.txt
+            # (DM) TODO: figure out how to flag/report number of unvertain samples and how to disqualify bad run(s)lines = log_data.split("\n")
+            lines = log_data.split("\n")
+            formatted_log_data = ""
+            for ii in range(len(lines)):
+                temp = lines[ii].split("Watts")
+                line_fixed = ""
+                for jj in range(len(temp)):
+                    line_fixed += temp[jj]
+                    if jj > 0 and (jj < len(temp) - 1 or len(temp) == 2):
+                        if jj == 1:
+                            if len(temp) == 2:
+                                line_fixed += ","
+                            line_fixed += "Mark," + self._id + "_testing"
+                            if len(temp) > 2:
+                                line_fixed += ","
+                        if len(temp) > 2:
+                            line_fixed += "Ch" + str(jj) + ","
+                    if jj < len(temp) - 1:
+                        line_fixed += "Watts"
+                formatted_log_data += line_fixed + "\n"
             with open(os.path.join(dirname, "spl.txt"), "w") as f:
                 f.write(formatted_log_data)
             with open(os.path.join(dirname, "ptd_out.txt"), "w") as f:

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -77,7 +77,6 @@ MAX_RANGE_FOR_DEVICE = {
     508: 20,  # WT210 DC
     549: 20,  # WT310 DC
     586: 20,  # WT330 DC
-
 }
 
 

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -965,11 +965,11 @@ class Session:
                 line_fixed = ""
                 for jj in range(len(temp)):
                     line_fixed += temp[jj]
-                    if jj > 0 and jj < len(temp)-1:
+                    if jj > 0 and jj < len(temp) - 1:
                         if jj == 1:
                             line_fixed += "Mark," + self._id + "_ranging,"
-                        line_fixed += "Ch"+str(jj) + ","
-                    if jj < len(temp)-1:
+                        line_fixed += "Ch" + str(jj) + ","
+                    if jj < len(temp) - 1:
                         line_fixed += "Watts"
                 formatted_log_data += line_fixed + "\n"
 

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -965,18 +965,14 @@ class Session:
                 line_fixed = ""
                 for jj in range(len(temp)):
                     line_fixed += temp[jj]
-                    if jj> 0 and jj<len(temp)-1:
+                    if jj > 0 and jj < len(temp)-1:
                         if jj == 1:
-                            line_fixed += "Mark,"+ self._id + "_ranging,"
-                        line_fixed += "Ch"+str(jj)+","
-                    if jj<len(temp)-1:
+                            line_fixed += "Mark," + self._id + "_ranging,"
+                        line_fixed += "Ch"+str(jj) + ","
+                    if jj < len(temp)-1:
                         line_fixed += "Watts"
-                formatted_log_data += line_fixed+"\n"
+                formatted_log_data += line_fixed + "\n"
 
-            # OLD:
-            # formatted_log_data = log_data.replace(
-            #     "\n", str(",Mark," + self._id + "_ranging\n")
-            # )  # honoring format of legacy spl.txt
             assert self._go_command_time is not None
             test_duration = time.monotonic() - self._go_command_time
             dirname = os.path.join(self.log_dir_path, "ranging")

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -39,6 +39,7 @@ from ptd_client_server.lib import common
 from ptd_client_server.lib import summary as summarylib
 from ptd_client_server.lib import time_sync
 
+PTD_READ_ALL_COMMAND_AC_MULTICH = "RL,*,*"
 PTD_READ_ALL_COMMAND_AC = "RL"
 PTD_READ_ALL_COMMAND_DC = "DC-RL"
 
@@ -475,8 +476,10 @@ class Ptd:
 
     def grab_power_data(self) -> Tuple[int, str, Optional[str], Optional[str]]:
         # (DM) Created method that will utilize SPEC's (only) preferred way of PTD usage and data gathering
-        power_data_header = self.cmd(PTD_READ_ALL_COMMAND_AC)  # RL - command to show unread samples
-        if "Unknown command" in power_data_header:
+        power_data_header = self.cmd(PTD_READ_ALL_COMMAND_AC_MULTICH)  # RL,*,* - command to show unread samples from all selected channels
+        if "Invalid number of parameters" in power_data_header:
+            power_data_header = self.cmd(PTD_READ_ALL_COMMAND_AC)  # RL - command to show unread samples
+        elif "Unknown command" in power_data_header:
             power_data_header = self.cmd(PTD_READ_ALL_COMMAND_DC)  # DC-RL - command to show unread samples in case of DC meter
         if power_data_header is not None:
             number_of_samples = int(

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -63,6 +63,8 @@ MULTICHANNEL_DEVICES = [48, 59, 61, 77]
 # https://github.com/mlcommons/power-dev/issues/220#issue-835336923
 DEVICE_TYPE_WT500 = 48
 
+DC_DEVICES = [508, 549, 586]
+
 MAX_RANGE_FOR_DEVICE = {
     8: 20,  # WT210
     49: 20,  # WT310
@@ -72,6 +74,10 @@ MAX_RANGE_FOR_DEVICE = {
     48: 40,  # WT500_multichannel
     47: 50,  # WT1800
     66: 30,  # WT5000
+    508: 20,  # WT210 DC
+    549: 20,  # WT310 DC
+    586: 20,  # WT330 DC
+
 }
 
 
@@ -296,11 +302,13 @@ class ServerConfig:
             "ptd", "channel", parse=parse_channel, fallback=None
         )
         self.ptd_device_type: int = get("ptd", "deviceType", parse=int)
+        ptd_dc_flag: Optional[str] = get("ptd", "dcFlag", fallback=None)
         ptd_interface_flag: str = get("ptd", "interfaceFlag")
         ptd_device_port: str = get("ptd", "devicePort")
         ptd_board_num: Optional[int] = get("ptd", "gpibBoard", parse=int, fallback=None)
         # TODO: validate ptd_interface_flag?
         # TODO: validate ptd_device_type?
+        # we can have a list of supported/tested devices and throw a warning when new device is used?
         self.ptd_logfile: str = os.path.join(self.tmp_dir.name, "ptd_logfile.txt")
         self.ptd_port: int = get("ptd", "networkPort", parse=int, fallback="8888")
         self.ptd_command: List[str] = [
@@ -315,6 +323,7 @@ class ServerConfig:
                 if self.ptd_channel is None
                 else ["-c", ",".join(str(x) for x in self.ptd_channel)]
             ),
+            *([] if ptd_dc_flag is None else [ptd_dc_flag]),
             *([] if ptd_interface_flag == "" else [ptd_interface_flag]),
             str(self.ptd_device_type),
             ptd_device_port,
@@ -324,6 +333,7 @@ class ServerConfig:
             "command": self.ptd_command,
             "device_type": self.ptd_device_type,
             "interface_flag": ptd_interface_flag,
+            "dc_flag": ptd_dc_flag,
             "device_port": ptd_device_port,
             "channel": self.ptd_channel,
         }

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -39,6 +39,8 @@ from ptd_client_server.lib import common
 from ptd_client_server.lib import summary as summarylib
 from ptd_client_server.lib import time_sync
 
+PTD_READ_ALL_COMMAND_AC = "RL"
+PTD_READ_ALL_COMMAND_DC = "DC-RL"
 
 RE_PTD_LOG = re.compile(
     r"""^
@@ -473,11 +475,13 @@ class Ptd:
 
     def grab_power_data(self) -> Tuple[int, str, Optional[str], Optional[str]]:
         # (DM) Created method that will utilize SPEC's (only) preferred way of PTD usage and data gathering
-        power_data_header = self.cmd("RL")  # RL - command to show unread samples
+        power_data_header = self.cmd(PTD_READ_ALL_COMMAND_AC)  # RL - command to show unread samples
+        if "Unknown command" in power_data_header:
+            power_data_header = self.cmd(PTD_READ_ALL_COMMAND_DC)  # DC-RL - command to show unread samples in case of DC meter
         if power_data_header is not None:
             number_of_samples = int(
                 power_data_header.split(" ")[1]
-            )  # first line of response will have message: "Last XYZ samples"
+            )  # first line of response will have message: "Last XYZ samples". in case of multich, it will hold inaccurate channel numbers, think how to get real stuff later
         else:
             number_of_samples = 0
         grabbed_power_data = self.read(number_of_samples)

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -954,10 +954,27 @@ class Session:
             self._state = SessionState.RANGING_DONE
             self._ptd.stop()
             samples, log_data, uncertainty_data, sanity = self._ptd.grab_power_data()
-            # (DM) TODO: figure out how to flag/report number of unvertain samples and how to disqualify bad run(s)
-            formatted_log_data = log_data.replace(
-                "\n", str(",Mark," + self._id + "_ranging\n")
-            )  # honoring format of legacy spl.txt
+            # (DM) really ugly function that will parse telnet log and reformat it in log that is same as ptd.log
+            # If anyone knows how to do it better, please do
+            lines = log_data.split("\n")
+            formatted_log_data = ""
+            for ii in range(len(lines)):
+                temp = lines[ii].split("Watts")
+                line_fixed = ""
+                for jj in range(len(temp)):
+                    line_fixed += temp[jj]
+                    if jj> 0 and jj<len(temp)-1:
+                        if jj == 1:
+                            line_fixed += "Mark,"+ self._id + "_ranging,"
+                        line_fixed += "Ch"+str(jj)+","
+                    if jj<len(temp)-1:
+                        line_fixed += "Watts"
+                formatted_log_data += line_fixed+"\n"
+
+            # OLD:
+            # formatted_log_data = log_data.replace(
+            #     "\n", str(",Mark," + self._id + "_ranging\n")
+            # )  # honoring format of legacy spl.txt
             assert self._go_command_time is not None
             test_duration = time.monotonic() - self._go_command_time
             dirname = os.path.join(self.log_dir_path, "ranging")

--- a/ptd_client_server/server.template.conf
+++ b/ptd_client_server/server.template.conf
@@ -57,3 +57,6 @@ devicePort: COM1
 # Channel value should consist of two numbers separated by a comma for a multichannel analyzer.
 # Channel value should consist of one number or be disabled for a 1-channel analyzer.
 #channel: 1,2
+
+# (Optional in case of DC meter) flag needed to specify to PTD that meter will be used as DC meter
+# dcFlag: -D


### PR DESCRIPTION
there are 3 different telnet commands to get power data from PTD (one for DC, one for AC, and another for multichannel AC).
Trick is that multichannel AC doesn't give same output as old logs which we always used.
Please someone take a look and potentially fix the monstrosity of the code that is fixing format