### PR TITLE
Fetch PAT with KSM in sync.yml

### DIFF
--- a/.github/workflows/inference_power_workflow.yaml
+++ b/.github/workflows/inference_power_workflow.yaml
@@ -35,8 +35,7 @@ jobs:
       with:
         keeper-secret-config: ${{ secrets.KSM_CONFIG }}
         secrets: |-
-          cAEVIvfzh_W2DWjhDoGiQQ/field/Access Token > env:ACCESS_TOKEN  # Fetch PAT and store in environment variable
- 
+          cAEVIvfzh_W2DWjhDoGiQQ/field/Access Token > env:ACCESS_TOKEN
     - name: Start power server
       run: |
         cm run script --tags=run,mlperf,power,server --device_type=0 --screen=yes --quiet --env.CM_GH_TOKEN=${{ env.ACCESS_TOKEN }}  # Use PAT fetched from Keeper

--- a/.github/workflows/inference_power_workflow.yaml
+++ b/.github/workflows/inference_power_workflow.yaml
@@ -28,10 +28,18 @@ jobs:
         python3 -m pip install cmind
         cm pull repo mlcommons@ck
         cm run script --quiet --tags=get,sys-utils-cm
+
+    - name: Retrieve secrets from Keeper
+      id: ksecrets
+      uses: Keeper-Security/ksm-action@master
+      with:
+        keeper-secret-config: ${{ secrets.KSM_CONFIG }}
+        secrets: |-
+          cAEVIvfzh_W2DWjhDoGiQQ/field/Access Token > env:PAT  # Fetch PAT and store in environment variable
  
     - name: Start power server
       run: |
-        cm run script --tags=run,mlperf,power,server --device_type=0 --screen=yes --quiet --env.CM_GH_TOKEN=${{ secrets.ACCESS_TOKEN }}
+        cm run script --tags=run,mlperf,power,server --device_type=0 --screen=yes --quiet --env.CM_GH_TOKEN=${{ env.PAT }}  # Use PAT fetched from Keeper
 
     - name: Test CM Script for MLPerf Inference ResNet50 with power
       run: |

--- a/.github/workflows/inference_power_workflow.yaml
+++ b/.github/workflows/inference_power_workflow.yaml
@@ -35,11 +35,11 @@ jobs:
       with:
         keeper-secret-config: ${{ secrets.KSM_CONFIG }}
         secrets: |-
-          cAEVIvfzh_W2DWjhDoGiQQ/field/Access Token > env:PAT  # Fetch PAT and store in environment variable
+          cAEVIvfzh_W2DWjhDoGiQQ/field/Access Token > env:ACCESS_TOKEN  # Fetch PAT and store in environment variable
  
     - name: Start power server
       run: |
-        cm run script --tags=run,mlperf,power,server --device_type=0 --screen=yes --quiet --env.CM_GH_TOKEN=${{ env.PAT }}  # Use PAT fetched from Keeper
+        cm run script --tags=run,mlperf,power,server --device_type=0 --screen=yes --quiet --env.CM_GH_TOKEN=${{ env.ACCESS_TOKEN }}  # Use PAT fetched from Keeper
 
     - name: Test CM Script for MLPerf Inference ResNet50 with power
       run: |

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
           secrets: |-
-            oISGH1N1wIEirucX9m5ung/field/Access Token > env:PAT  # Fetch PAT and store in environment variable
+            oISGH1N1wIEirucX9m5ung/field/Access Token > env:INFERENCE_ACCESS_TOKEN  # Fetch PAT and store in environment variable
       - name: Run GitHub File Sync
         uses: BetaHuhn/repo-file-sync-action@v1
         with:
-          GH_PAT: ${{ env.PAT }}  # Use PAT fetched from Keeper
+          GH_PAT: ${{ env.INFERENCE_ACCESS_TOKEN }}  # Use PAT fetched from Keeper
           TEAM_REVIEWERS: wg-inference
           SKIP_PR: false

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
           secrets: |-
-            oISGH1N1wIEirucX9m5ung/field/Access Token > env:INFERENCE_ACCESS_TOKEN  # Fetch PAT and store in environment variable
+            oISGH1N1wIEirucX9m5ung/field/Access Token > env:INFERENCE_ACCESS_TOKEN 
       - name: Run GitHub File Sync
         uses: BetaHuhn/repo-file-sync-action@v1
         with:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -11,9 +11,16 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@master
+      - name: Retrieve secrets from Keeper
+        id: ksecrets
+        uses: Keeper-Security/ksm-action@master
+        with:
+          keeper-secret-config: ${{ secrets.KSM_CONFIG }}
+          secrets: |-
+            oISGH1N1wIEirucX9m5ung/field/Access Token > env:PAT  # Fetch PAT and store in environment variable
       - name: Run GitHub File Sync
         uses: BetaHuhn/repo-file-sync-action@v1
         with:
-          GH_PAT: ${{ secrets.INFERENCE_ACCESS_TOKEN }}
+          GH_PAT: ${{ env.PAT }}  # Use PAT fetched from Keeper
           TEAM_REVIEWERS: wg-inference
           SKIP_PR: false


### PR DESCRIPTION
This PR implements KSM to fetch the `ACCESS_TOKEN` and `INFERENCE_ACCESS_TOKEN` from Keeper rather than the GitHub repository secrets. We are implementing KSM across our infrastructure to centralize key management and streamline key rolling. The current keys in the repo expire on Jan 12th, so we are taking this expiration as an opportunity to switch to KSM.