### PR TITLE
Switch from KSM to 1Password in GitHub Actions

### DIFF
--- a/.github/workflows/inference_power_workflow.yaml
+++ b/.github/workflows/inference_power_workflow.yaml
@@ -31,9 +31,7 @@ jobs:
 
       - name: Load secret
         id: op-load-secret
-        uses: 1password/load-secrets-action@v2
-        with:
-          export-env: false
+        uses: 1password/load-secrets-action@v3
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ACCESS_TOKEN: op://pwlc2kez7wyl6pfbgewware4vy/jzk6yvmfz5s65fxfvlbijttcry/credential

--- a/.github/workflows/inference_power_workflow.yaml
+++ b/.github/workflows/inference_power_workflow.yaml
@@ -9,6 +9,7 @@ jobs:
    cm_check:
     name: Check power workflow
     runs-on: "${{ matrix.on }}"
+    environment: master
     strategy:
       fail-fast: false
       matrix:
@@ -28,16 +29,17 @@ jobs:
         python3 -m pip install cm4mlops
         cm run script --quiet --tags=get,sys-utils-cm
 
-    - name: Retrieve secrets from Keeper
-      id: ksecrets
-      uses: Keeper-Security/ksm-action@master
-      with:
-        keeper-secret-config: ${{ secrets.KSM_CONFIG }}
-        secrets: |-
-          cAEVIvfzh_W2DWjhDoGiQQ/field/Access Token > env:ACCESS_TOKEN
+      - name: Load secret
+        id: op-load-secret
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          ACCESS_TOKEN: op://pwlc2kez7wyl6pfbgewware4vy/jzk6yvmfz5s65fxfvlbijttcry/credential
     - name: Start power server
       run: |
-        cm run script --tags=run,mlperf,power,server --device_type=0 --screen=yes --quiet --env.CM_GH_TOKEN=${{ env.ACCESS_TOKEN }}  # Use PAT fetched from Keeper
+        cm run script --tags=run,mlperf,power,server --device_type=0 --screen=yes --quiet --env.CM_GH_TOKEN=${{ steps.op-load-secret.outputs.ACCESS_TOKEN }}
 
     - name: Test CM Script for MLPerf Inference ResNet50 with power
       run: |

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -7,20 +7,22 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    environment: master
     if: github.repository == 'mlcommons/power-dev'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@master
-      - name: Retrieve secrets from Keeper
-        id: ksecrets
-        uses: Keeper-Security/ksm-action@master
+      - name: Load secret
+        id: op-load-secret
+        uses: 1password/load-secrets-action@v2
         with:
-          keeper-secret-config: ${{ secrets.KSM_CONFIG }}
-          secrets: |-
-            oISGH1N1wIEirucX9m5ung/field/Access Token > env:INFERENCE_ACCESS_TOKEN 
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          INFERENCE_ACCESS_TOKEN: op://pwlc2kez7wyl6pfbgewware4vy/tcycqeki2ekffq4w2v7tret5om/credential
       - name: Run GitHub File Sync
         uses: BetaHuhn/repo-file-sync-action@v1
         with:
-          GH_PAT: ${{ env.INFERENCE_ACCESS_TOKEN }}  # Use PAT fetched from Keeper
+          GH_PAT: ${{ steps.op-load-secret.outputs.INFERENCE_ACCESS_TOKEN }}
           TEAM_REVIEWERS: wg-inference
           SKIP_PR: false


### PR DESCRIPTION
This PR implements replaces KSM with 1Password to fetch the ACCESS_TOKEN and INFERENCE_ACCESS_TOKEN. We are currently transitioning from Keeper to 1Password. The current keys in the Keeper are now expired, so this PR will need to be merged for the sync.yml and inference_power_workflow.yaml workflows to work correctly. Sorry for the disruption so soon after implementing KSM.